### PR TITLE
Multi-arch builds using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+  multi:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            vidurb/wireguard-transmission:build-with-github-actions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            vidurb/wireguard-transmission:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/wireguard-transmission:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - master
+      - build-with-github-actions
 
 jobs:
   multi:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: 
       - master
-      - build-with-github-actions
 
 jobs:
   multi:
@@ -34,4 +33,4 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            vidurb/wireguard-transmission:build-with-github-actions
+            vidurb/wireguard-transmission:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          image: docker/binfmt
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        with:
-          image: docker/binfmt
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: true
           tags: |
             vidurb/wireguard-transmission:build-with-github-actions


### PR DESCRIPTION
Hi Seb,
I'd forked your image to add some features I needed and figured I'd contribute some work upstream also to thank you for your very useful image, so I set up multi-architecture image builds using GitHub Actions, which I saw was on your feature list. Hopefully this PR is of some use to you, but I understand if you have reservations about using GitHub Actions - I saw that you were planning on waiting till Docker Hub supported multi-arch builds natively.

I've tested the build process fine, but I haven't tested the generated images themselves as I don't have any ARM hardware to do so. I've asked a friend to do so. I also didn't enable building for a couple more architectures because I had no idea how I'd be able to test it on those, but it should be relatively simple to enable those if you need.

My repo's main branch has some more stuff I'd be happy to help integrate if you think they'd be good additions:
- I added automatic generation of the configuration file from passed & default environment variables, as the image I was using previously handled configuration like that. (Uses dockerize)
- I added S6 overlay and switched to running transmission as a non-root user and letting the UID and GID be specified with env vars

Thanks,
Vidur

P.S. I didn't allow edit access to this PR because that would expose my secret variables from GitHub Actions (DockerHub token) but I'm happy to make any changes you'd like.